### PR TITLE
[HUBS-1289] [HUBS-1290] [HUBS-1291] Readme, schedule event, standard input params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Delphix Data Control Tower's Data Source with New Relic
+# Delphix Data Control Tower's Integration with New Relic
 
 This project will allow you to send data from [Delphix Data Control Tower (DCT)](https://delphix.document360.io/dct/docs) to [New Relic](https://newrelic.com/) through the Events API. This repository is one component of the Delphix Quickstart. You can learn more on the [Delphix Instant Observability page](https://newrelic.com/instant-observability/delphix).
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,43 @@
 # Delphix Data Control Tower's Data Source with New Relic
 
-This project will allow you to send data from [Delphix Data Control Tower (DCT)](https://delphix.document360.io/dct/docs) to [New Relic](https://newrelic.com/) through the Events API. This repository is one component of the Delphix Quickstart. More can be learned about the [soultion on the New Relic website](https://newrelic.com/instant-observability/delphix).
+This project will allow you to send data from [Delphix Data Control Tower (DCT)](https://delphix.document360.io/dct/docs) to [New Relic](https://newrelic.com/) through the Events API. This repository is one component of the Delphix Quickstart. You can learn more on the [Delphix Instant Observability page](https://newrelic.com/instant-observability/delphix).
 
 ![Screenshot](images/image2.png)
 
 
 ## Getting Started
 
-These instructions will provide the information you need to extract data from DCT and send it to New Relic. 
+These instructions will provide the information you need to extract data from DCT and send it to New Relic. The Python script can run from any location with access to both DCT and New Relic.
 
 
 ### Prerequisites
 
 * New Relic Account: [Sign Up](https://newrelic.com/signup)
 * Delphix Data Control Tower (DCT) with one or more engines: [Data Control Tower Docs](https://delphix.document360.io/dct/docs)
-* Python 3.10: [Python Install](https://www.python.org/downloads)
-* New Relic Python SDK: [Installation Directions](https://github.com/newrelic/newrelic-telemetry-sdk-python)
+* Python 3.11+: [Python Install](https://www.python.org/downloads)
 * This [GitHub repository](https://github.com/delphix/dct-newrelic-integration)
 
+Note: If you are using Windows, `py` may be specified instead of `python`.
 
-### Configuration
 
+### Setup
 The ```dlpx_dct_to_nr.py``` script contains the logic to perform the data upload. However, you must do some configuration first. 
 
+#### Package Installation
+Run the following 2 pip installation commands to install the required Python packages:
+```python -m pip install requests```
+```python -m pip install newrelic_telemetry_sdk```
+
+#### Environment Variable Configuration
 Retrieve the following:
 * Record the DCT URL.
-* Generate a [DCT APK](https://delphix.document360.io/docs).
-* Generate a [New Relic User Key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
+* Generate a [DCT API Key](https://delphix.document360.io/docs/authentication
+* Generate a [New Relic INGEST - LICENSE Key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
 
 Once we have these values, specify the following environment variables:
 * DCT_URL
 * DCT_KEY
-* NEW_RELIC_USER_KEY
+* NEW_RELIC_KEY
 
 Note: You may modify the Python script directly, but it is best practice to specify sensitive data through environment variables.
 
@@ -41,7 +47,7 @@ Note: You may modify the Python script directly, but it is best practice to spec
 You may test the script by running the following command:
 ```python dlpx_dct_to_nr.py```
 
-In production, it is common to use a scheduler, such as a cron, to repeat the call on a recurring basis. For example, the following command will run the script every 5 minutes:
+In production, it is common to use a scheduler, such as a cron on Unix or SCHTASKS on Windows, to repeat the call on a recurring basis. For example, the following cron command will run the script every 5 minutes:
 ```*/5 * * * * python dlpx_dct_to_nr.py```
 
 On each execution, this script will extract the following metrics from all registered Delphix engines:

--- a/dlpx_dct_to_nr.py
+++ b/dlpx_dct_to_nr.py
@@ -8,7 +8,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-DLPX_TYPES= ["engines","sources","dsources","vdbs","environments"]
+DLPX_TYPES= ["management/engines","sources","dsources","vdbs","environments"]
 
 #
 # Required Input Parameters
@@ -34,7 +34,7 @@ req_headers = {
 }
 
 for i in DLPX_TYPES:
-	response = requests.get(DCT_URL + '/v1/' + i, headers=req_headers, verify=False)
+	response = requests.get(DCT_URL + '/v2/' + i, headers=req_headers, verify=False)
 	responsej = json.loads(response.text)
 	print("")
 	print("")

--- a/dlpx_dct_to_nr.py
+++ b/dlpx_dct_to_nr.py
@@ -9,12 +9,17 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 DLPX_TYPES= ["engines","sources","dsources","vdbs","environments"]
+
 #
-# Request Headers ...
+# Required Input Parameters
 #
-req_headers = {
-	'Authorization': 'apk 2.bnQDDx46Z4CDlIShLw2ZHElWLyKtsmZaBjbQPjui8LcQ3TELbkdEbQJSki6vmwLf'
-}
+try:
+	DCT_URL = os.environ["DCT_URL"] # Example: https://localhost:443
+	DCT_KEY = os.environ['DCT_KEY'] # Example: 'apk 2.bnQDDx46Z4CDlIShLw2ZHElWLyKtsmZaBjbQPjui8LcQ3TELbkdEbQJSki6vmwLf'
+	NEW_RELIC_USER_KEY = os.environ['NEW_RELIC_USER_KEY'] # Generated User Key from https://one.newrelic.com/admin-portal/api-keys/home
+except:
+	print ("[Error] One or more of the DCT_URL, DCT_KEY, OR NEW_RELIC_USER_KEY environment variables are empty. Ensure all values are specified.")
+	exit()
 
 #
 # Python session, also handles the cookies ...
@@ -22,18 +27,19 @@ req_headers = {
 session = requests.session()
 
 #
-# Login ...
+# Request Headers ...
 #
-os.environ['NEW_RELIC_INSERT_KEY'] = "87a453b2efe4bd4df78b167e7ac457e076c7NRAL"
-print ('')
-for i in DLPX_TYPES:
+req_headers = {
+	'Authorization': DCT_KEY
+}
 
-	response = requests.get('https://localhost:443/v1/'+i, headers=req_headers, verify=False)
+for i in DLPX_TYPES:
+	response = requests.get(DCT_URL + '/v1/' + i, headers=req_headers, verify=False)
 	responsej = json.loads(response.text)
 	print("")
 	print("")
 	print("**********************************************************************************************************************************")
-	event_client = EventClient(os.environ["NEW_RELIC_INSERT_KEY"])
+	event_client = EventClient(NEW_RELIC_USER_KEY)
 	NEWRELIC_TYPE="Delphix " + str(i)
 	print (NEWRELIC_TYPE)
 	for line in responsej['items']:

--- a/dlpx_dct_to_nr.py
+++ b/dlpx_dct_to_nr.py
@@ -4,9 +4,12 @@ import json
 import sys
 import time
 from newrelic_telemetry_sdk import Event, EventClient
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+##
+# Uncomment the following lines to ignore SSL Warnings
+##
+# from requests.packages.urllib3.exceptions import InsecureRequestWarning
+# requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 DLPX_TYPES= ["management/engines","sources","dsources","vdbs","environments"]
 
@@ -16,9 +19,9 @@ DLPX_TYPES= ["management/engines","sources","dsources","vdbs","environments"]
 try:
 	DCT_URL = os.environ["DCT_URL"] # Example: https://localhost:443
 	DCT_KEY = os.environ['DCT_KEY'] # Example: 'apk 2.bnQDDx46Z4CDlIShLw2ZHElWLyKtsmZaBjbQPjui8LcQ3TELbkdEbQJSki6vmwLf'
-	NEW_RELIC_USER_KEY = os.environ['NEW_RELIC_USER_KEY'] # Generated User Key from https://one.newrelic.com/admin-portal/api-keys/home
+	NEW_RELIC_KEY = os.environ['NEW_RELIC_KEY'] # Generated "INGEST - LICENSE" Key from https://one.newrelic.com/admin-portal/api-keys/home
 except:
-	print ("[Error] One or more of the DCT_URL, DCT_KEY, OR NEW_RELIC_USER_KEY environment variables are empty. Ensure all values are specified.")
+	print ("[Error] One or more of the DCT_URL, DCT_KEY, OR NEW_RELIC_KEY environment variables are empty. Ensure all values are specified.")
 	exit()
 
 #
@@ -34,24 +37,22 @@ req_headers = {
 }
 
 for i in DLPX_TYPES:
+	NEWRELIC_TYPE = "Delphix " + str(i)	
+	print ("Uploading events: " + NEWRELIC_TYPE)
 	response = requests.get(DCT_URL + '/v2/' + i, headers=req_headers, verify=False)
 	responsej = json.loads(response.text)
-	print("")
-	print("")
-	print("**********************************************************************************************************************************")
-	event_client = EventClient(NEW_RELIC_USER_KEY)
-	NEWRELIC_TYPE="Delphix " + str(i)
-	print (NEWRELIC_TYPE)
+	# print("")
+	# print("")
+	# print("**********************************************************************************************************************************")
+	event_client = EventClient(NEW_RELIC_KEY)
 	for line in responsej['items']:
 		event = Event(
 			NEWRELIC_TYPE, line
 		)
-		print (event)
+		# print (event)
 		response = event_client.send(event)
 		response.raise_for_status()
-		print("Event sent successfully!")
-		print("")
+	print ("Upload successful: " + NEWRELIC_TYPE)
 
-print ('')
 sys.exit(0)
 


### PR DESCRIPTION
# Problem:
Various updates to clean the initial user journey when installing the data source with New Relic and DCT.

# Solution:
- Removed mentions of Multicloud. Updated with just DCT.
- Cleaned up config and installation directions in the README.md
- Specified environment variables for Input. (Best practices for API Keys.) Introduced clearer error response.
- API v2 Changes
  - engines -> management/engines
